### PR TITLE
DocsRequest 테이블 컬럼명 수정 및 새문서 요청 관련 이슈 처리

### DIFF
--- a/src/main/java/com/timcooki/jnuwiki/domain/docsRequest/entity/DocsRequest.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/docsRequest/entity/DocsRequest.java
@@ -8,12 +8,8 @@ import com.timcooki.jnuwiki.util.auditing.BaseTimeEntity;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.annotation.CreatedBy;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 
 
 @Entity
@@ -31,11 +27,11 @@ public class DocsRequest extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private DocsRequestType docsRequestType;
 
-    @Column(name = "docs_category", nullable = false)
+    @Column(name = "docs_request_category", nullable = false)
     @Enumerated(EnumType.STRING)
     private DocsCategory docsRequestCategory;
 
-    @Column(name = "docs_name", nullable = false)
+    @Column(name = "docs_request_name", nullable = false)
     private String docsRequestName;
 
     @Embedded

--- a/src/main/java/com/timcooki/jnuwiki/domain/member/service/AdminService.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/member/service/AdminService.java
@@ -27,9 +27,8 @@ public class AdminService {
 
     // TODO - 예외처리 수정
     // 새 문서 요청 승락
+    @Transactional
     public NewApproveResDTO approveNewDocs(Long docsRequestId){
-
-
         DocsRequest docsRequest = docsRequestRepository.findById(docsRequestId).orElseThrow(
                 () -> new Exception404("존재하지 않는 요청입니다.")
         );
@@ -51,20 +50,16 @@ public class AdminService {
                 .docsCategory(docs.getDocsCategory().getCategory())
                 .docsName(docs.getDocsName())
                 .docsLocation(docs.getDocsLocation())
+                .docsCreatedAt(docs.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss")))
                 .build();
-
-        //DocsCreateDTO createdDocs = docsRequestService.createDocsFromRequest(docsRequestId);
     }
 
     @Transactional
     public InfoEditResDTO updateDocsFromRequest(Long docsRequestId) {
-
-        // 승락받은 요청 조회
         DocsRequest modifiedRequest = docsRequestRepository.findById(docsRequestId).orElseThrow(
                 () -> new Exception404("존재하지 않는 요청입니다.")
         );
 
-        // 수정할 문서 조회
         Long docsId = modifiedRequest.getDocs().getDocsId();
         Docs docs = docsRepository.findById(docsId).orElseThrow(
                 () -> new Exception404("수정하려는 문서가 존재하지 않습니다.")


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 사항
- DocsRequest 엔티티 클래스에서 필드명과 동일하게 테이블의 컬럼명 이름을 수정
- 문서 생성 요청 승락을 처리하는 메서드에 트랜잭션 처리
- 문서 생성 요청 승락에 대한 응답 DTO에 누락된 새 문서 생성 시간 추가