### PR TITLE
마이페이지 스크랩 응답 DTO 구현 및 문서 조회 응답 수정

### DIFF
--- a/src/main/java/com/timcooki/jnuwiki/domain/docs/DTO/response/ListReadResDTO.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/docs/DTO/response/ListReadResDTO.java
@@ -10,11 +10,7 @@ public record ListReadResDTO(
         String docsName,
         // TODO Type 변경 - ENUM
         String docsCategory,
-        DocsLocation docsLocation,
-        String docsContent,
-        String docsCreatedBy,
-        String docsCreatedAt,
-        String docsModifiedAt
+        boolean scrap
 ) {
     @Builder
     public ListReadResDTO {

--- a/src/main/java/com/timcooki/jnuwiki/domain/docs/DTO/response/ReadResDTO.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/docs/DTO/response/ReadResDTO.java
@@ -14,7 +14,8 @@ public record ReadResDTO(
         DocsLocation docsLocation,
         String docsContent,
         String docsCreatedBy,
-        String docsCreatedAt
+        String docsCreatedAt,
+        boolean scrap
 ) {
     @Builder
     public ReadResDTO {

--- a/src/main/java/com/timcooki/jnuwiki/domain/member/DTO/response/ScrapResDTO.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/member/DTO/response/ScrapResDTO.java
@@ -1,0 +1,15 @@
+package com.timcooki.jnuwiki.domain.member.DTO.response;
+
+import lombok.Builder;
+
+// 멤버가 스크랩한 게시글 응답
+public record ScrapResDTO (
+        Long docsId,
+        String docsName,
+        String docsCategory
+){
+
+    @Builder
+    public ScrapResDTO {
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 사항

+ 마이페이지에서 <스크랩한 게시글 보기>에 사용될 응답 DTO 생성
+ 문서 상세 조회의 응답 DTO에 사용자의 스크랩 여부를 나타내는 필드 추가
+ 문서 목록 조회의 응답 DTO에 사용자의 스크랩 여부를 나타내는 필드 추가
+ 문서 목록 조회 화면에서 사용되지 않는 데이터 제거

### 관련 이슈
Closes #39 