### PR TITLE
Write, ReadService로 분리 및 리프레시 토큰 재발급 오류 해결, 리팩토링

### DIFF
--- a/src/main/java/com/timcooki/jnuwiki/domain/docsRequest/controller/DocsRequestController.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/docsRequest/controller/DocsRequestController.java
@@ -6,7 +6,6 @@ import com.timcooki.jnuwiki.domain.docsRequest.service.DocsRequestWriteService;
 import com.timcooki.jnuwiki.util.ApiUtils;
 import com.timcooki.jnuwiki.domain.docsRequest.dto.request.NewWriteReqDTO;
 import com.timcooki.jnuwiki.domain.docsRequest.dto.request.EditWriteReqDTO;
-import com.timcooki.jnuwiki.domain.docsRequest.service.DocsRequestReadService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/timcooki/jnuwiki/domain/docsRequest/controller/DocsRequestController.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/docsRequest/controller/DocsRequestController.java
@@ -2,10 +2,11 @@ package com.timcooki.jnuwiki.domain.docsRequest.controller;
 
 
 import com.timcooki.jnuwiki.domain.docsRequest.dto.response.NewWriteResDTO;
+import com.timcooki.jnuwiki.domain.docsRequest.service.DocsRequestWriteService;
 import com.timcooki.jnuwiki.util.ApiUtils;
 import com.timcooki.jnuwiki.domain.docsRequest.dto.request.NewWriteReqDTO;
 import com.timcooki.jnuwiki.domain.docsRequest.dto.request.EditWriteReqDTO;
-import com.timcooki.jnuwiki.domain.docsRequest.service.DocsRequestService;
+import com.timcooki.jnuwiki.domain.docsRequest.service.DocsRequestReadService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,30 +21,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/requests")
 public class DocsRequestController {
-    private final DocsRequestService docsRequestService;
+    private final DocsRequestWriteService writeService;
 
     // 문서 수정 요청 작성
     @PostMapping("/update")
     public ResponseEntity<?> writeModifiedRequest(@AuthenticationPrincipal UserDetails userDetails, @RequestBody EditWriteReqDTO modifiedRequestWriteDto) {
-        // 권한 확인
-
-        // 요청 저장
-        docsRequestService.createModifiedRequest(userDetails, modifiedRequestWriteDto);
-
-        // 요청 반환
+        writeService.createModifiedRequest(userDetails, modifiedRequestWriteDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiUtils.success(new NewWriteResDTO("요청이 저장되었습니다.")));
     }
 
     // 문서 생성 요청 작성
     @PostMapping("/new")
     public ResponseEntity<?> writeCreateRequest(@AuthenticationPrincipal UserDetails userDetails, @RequestBody NewWriteReqDTO newWriteReqDTO) {
-        // TODO - CustomUserDetails | findByEmail
-
-
-        // 문서 저장
-        docsRequestService.createNewDocsRequest(userDetails, newWriteReqDTO);
-
-        // 요청 반환
+        writeService.createNewDocsRequest(userDetails, newWriteReqDTO);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiUtils.success(new NewWriteResDTO("요청이 저장되었습니다.")));
     }
 }

--- a/src/main/java/com/timcooki/jnuwiki/domain/docsRequest/service/DocsRequestReadService.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/docsRequest/service/DocsRequestReadService.java
@@ -1,10 +1,5 @@
 package com.timcooki.jnuwiki.domain.docsRequest.service;
 
-import com.timcooki.jnuwiki.domain.docs.entity.Docs;
-import com.timcooki.jnuwiki.domain.docs.repository.DocsRepository;
-import com.timcooki.jnuwiki.domain.docsRequest.dto.request.EditWriteReqDTO;
-import com.timcooki.jnuwiki.domain.docsRequest.dto.request.NewWriteReqDTO;
-import com.timcooki.jnuwiki.domain.docsRequest.entity.DocsCategory;
 import com.timcooki.jnuwiki.domain.docsRequest.entity.DocsRequest;
 import com.timcooki.jnuwiki.domain.docsRequest.entity.DocsRequestType;
 import com.timcooki.jnuwiki.domain.docsRequest.mapper.DocsRequestMapper;
@@ -13,70 +8,28 @@ import com.timcooki.jnuwiki.domain.member.DTO.response.admin.EditListReadResDTO;
 import com.timcooki.jnuwiki.domain.member.DTO.response.admin.EditReadResDTO;
 import com.timcooki.jnuwiki.domain.member.DTO.response.admin.NewListReadResDTO;
 import com.timcooki.jnuwiki.domain.member.DTO.response.admin.NewReadResDTO;
-import com.timcooki.jnuwiki.domain.member.entity.Member;
-import com.timcooki.jnuwiki.domain.member.repository.MemberRepository;
 import com.timcooki.jnuwiki.util.errors.exception.Exception400;
 import com.timcooki.jnuwiki.util.errors.exception.Exception404;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.mapstruct.factory.Mappers;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
-public class DocsRequestService {
+public class DocsRequestReadService {
 
     private final DocsRequestRepository docsRequestRepository;
 
-    private final MemberRepository memberRepository;
-    private final DocsRepository docsRepository;
-
-    public void createModifiedRequest(UserDetails userDetails, EditWriteReqDTO modifiedRequestWriteDto) {
-        DocsRequestMapper mapper = Mappers.getMapper(DocsRequestMapper.class);
-
-        // TODO - 15일 지났는지 체크 추가
-
-        Docs docs = docsRepository.findById(modifiedRequestWriteDto.docsId()).orElseThrow(() -> new Exception404("존재하지 않는 문서 입니다."));
-
-        Member member = memberRepository.findByEmail(userDetails.getUsername()).orElseThrow(() -> new Exception400("잘못된 요청입니다."));
-        DocsRequest docsRequest = mapper.editDTOToEntity(modifiedRequestWriteDto, docs, member, DocsCategory.nameOf(modifiedRequestWriteDto.docsRequestCategory()));
-        docsRequestRepository.save(docsRequest);
-    }
-
-    public void createNewDocsRequest(UserDetails userDetails, NewWriteReqDTO newWriteReqDTO) {
-        //checkMemberDuration(userDetails);
-
-        DocsRequestMapper mapper = Mappers.getMapper(DocsRequestMapper.class);
-
-        Member member = memberRepository.findByEmail(userDetails.getUsername()).orElseThrow(() -> new Exception400("잘못된 요청입니다."));
-
-        // TODO - 15일 지났는지 체크 추가
-
-        DocsRequest docsRequest = mapper.newDTOToEntity(newWriteReqDTO, member, DocsCategory.nameOf(newWriteReqDTO.docsRequestCategory()));
-        docsRequestRepository.save(docsRequest);
-    }
-
-    public void checkMemberDuration(UserDetails userDetails) {
-        // 권한 확인(회원가입 15일)
-        Member member = memberRepository.findByEmail(userDetails.getUsername()).get();
-        if (ChronoUnit.DAYS.between(member.getCreatedAt(), LocalDateTime.now())>15){
-            throw new RuntimeException("회원가입 후 15일이 지난 회원만 요청이 가능합니다.");//403 forbidden
-        }
-    }
 
     // 기본정보 수정 요청 목록 조회
-    // TODO: 테스트 코드 작성
     public EditListReadResDTO getModifiedRequestList(Pageable pageable) {
         DocsRequestMapper mapper = Mappers.getMapper(DocsRequestMapper.class);
-
         List<DocsRequest> docsRequests = docsRequestRepository.findAllByDocsRequestType(DocsRequestType.MODIFIED, pageable).getContent();
 
         List<EditReadResDTO> modifiedList = docsRequests.stream()
@@ -94,7 +47,6 @@ public class DocsRequestService {
 
     public NewListReadResDTO getCreatedRequestList(Pageable pageable) {
         DocsRequestMapper mapper = Mappers.getMapper(DocsRequestMapper.class);
-
         List<DocsRequest> docsRequests = docsRequestRepository.findAllByDocsRequestType(DocsRequestType.CREATED, pageable).getContent();
 
         List<NewReadResDTO> newList = docsRequests.stream()
@@ -112,7 +64,6 @@ public class DocsRequestService {
 
     public EditReadResDTO getOneModifiedRequest(Long docsRequestId) {
         DocsRequestMapper mapper = Mappers.getMapper(DocsRequestMapper.class);
-
         DocsRequest docsRequest = docsRequestRepository.findById(docsRequestId).orElseThrow(() -> new Exception404("존재하지 않는 요청입니다."));
 
         // 수정된문서 요청이 아닌경우
@@ -121,13 +72,11 @@ public class DocsRequestService {
         }
 
         EditReadResDTO editReadResDTO = mapper.editEntityToDTO(docsRequest, docsRequest.getDocsRequestCategory().getCategory());
-
         return editReadResDTO;
     }
 
     public NewReadResDTO getOneCreatedRequest(Long docsRequestId) {
         DocsRequestMapper mapper = Mappers.getMapper(DocsRequestMapper.class);
-
         DocsRequest docsRequest = docsRequestRepository.findById(docsRequestId).orElseThrow(() -> new Exception404("존재하지 않는 요청입니다."));
 
         // 새문서 요청이 아닌경우
@@ -135,21 +84,7 @@ public class DocsRequestService {
             throw new Exception400("잘못된 요청입니다.");
         }
 
-
         NewReadResDTO newReadResDTO = mapper.newEntityToDTO(docsRequest, docsRequest.getDocsRequestCategory().getCategory());
-
         return newReadResDTO;
-    }
-
-
-    public void rejectRequest(Long docsRequestId) {
-        // 요청 존재 확인
-        DocsRequest docsRequest = docsRequestRepository.findById(docsRequestId).orElseThrow(() -> new Exception404("존재하지 않는 요청입니다."));
-
-        docsRequestRepository.delete(docsRequest);
-    }
-
-    public boolean hasRequest(Long docsRequestId) {
-        return docsRequestRepository.findById(docsRequestId).isPresent();
     }
 }

--- a/src/main/java/com/timcooki/jnuwiki/domain/docsRequest/service/DocsRequestWriteService.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/docsRequest/service/DocsRequestWriteService.java
@@ -1,0 +1,43 @@
+package com.timcooki.jnuwiki.domain.docsRequest.service;
+
+import com.timcooki.jnuwiki.domain.docs.entity.Docs;
+import com.timcooki.jnuwiki.domain.docs.repository.DocsRepository;
+import com.timcooki.jnuwiki.domain.docsRequest.dto.request.EditWriteReqDTO;
+import com.timcooki.jnuwiki.domain.docsRequest.dto.request.NewWriteReqDTO;
+import com.timcooki.jnuwiki.domain.docsRequest.entity.DocsCategory;
+import com.timcooki.jnuwiki.domain.docsRequest.entity.DocsRequest;
+import com.timcooki.jnuwiki.domain.docsRequest.mapper.DocsRequestMapper;
+import com.timcooki.jnuwiki.domain.docsRequest.repository.DocsRequestRepository;
+import com.timcooki.jnuwiki.domain.member.entity.Member;
+import com.timcooki.jnuwiki.domain.member.repository.MemberRepository;
+import com.timcooki.jnuwiki.util.errors.exception.Exception400;
+import com.timcooki.jnuwiki.util.errors.exception.Exception404;
+import lombok.RequiredArgsConstructor;
+import org.mapstruct.factory.Mappers;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DocsRequestWriteService {
+    private final DocsRequestRepository docsRequestRepository;
+    private final MemberRepository memberRepository;
+    private final DocsRepository docsRepository;
+
+    public void createModifiedRequest(UserDetails userDetails, EditWriteReqDTO modifiedRequestWriteDto) {
+        DocsRequestMapper mapper = Mappers.getMapper(DocsRequestMapper.class);
+        Docs docs = docsRepository.findById(modifiedRequestWriteDto.docsId()).orElseThrow(() -> new Exception404("존재하지 않는 문서 입니다."));
+
+        Member member = memberRepository.findByEmail(userDetails.getUsername()).orElseThrow(() -> new Exception400("잘못된 요청입니다."));
+        DocsRequest docsRequest = mapper.editDTOToEntity(modifiedRequestWriteDto, docs, member, DocsCategory.nameOf(modifiedRequestWriteDto.docsRequestCategory()));
+        docsRequestRepository.save(docsRequest);
+    }
+
+    public void createNewDocsRequest(UserDetails userDetails, NewWriteReqDTO newWriteReqDTO) {
+        DocsRequestMapper mapper = Mappers.getMapper(DocsRequestMapper.class);
+        Member member = memberRepository.findByEmail(userDetails.getUsername()).orElseThrow(() -> new Exception400("잘못된 요청입니다."));
+
+        DocsRequest docsRequest = mapper.newDTOToEntity(newWriteReqDTO, member, DocsCategory.nameOf(newWriteReqDTO.docsRequestCategory()));
+        docsRequestRepository.save(docsRequest);
+    }
+}

--- a/src/main/java/com/timcooki/jnuwiki/domain/member/controller/AdminController.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/member/controller/AdminController.java
@@ -13,10 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -29,9 +26,6 @@ public class AdminController {
     // 문서 기본정보 수정 요청 목록 조회
     @GetMapping("/admin/requests/update")
     private ResponseEntity<?> getModifiedRequests(@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        // 권한 확인
-
-        // 요청 목록 조회
         EditListReadResDTO modifiedRequests = docsRequestService.getModifiedRequestList(pageable);
         return ResponseEntity.ok().body(ApiUtils.success(modifiedRequests));
     }
@@ -39,9 +33,6 @@ public class AdminController {
     // 새 문서 생성 요청 목록 조회
     @GetMapping("/admin/requests/new")
     private Object getCreatedRequests(@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        // 권한 확인
-        log.info("새 문서 생성 요청 목록 조회 컨트롤러 접속 성공");
-        // 요청 목록 조회
         NewListReadResDTO createRequests = docsRequestService.getCreatedRequestList(pageable);
         return ApiUtils.success(createRequests);
     }
@@ -49,12 +40,6 @@ public class AdminController {
     // 문서 기본 정보 수정 요청 상세 조회
     @GetMapping("/admin/requests/update/{docs_request_id}")
     private Object getOneModifiedRequest(@PathVariable("docs_request_id") Long docsRequestId) {
-        // 권한 확인
-
-
-        // 요청 존재 확인
-
-
         EditReadResDTO modifiedRequest = docsRequestService.getOneModifiedRequest(docsRequestId);
         return ApiUtils.success(modifiedRequest);
     }
@@ -62,11 +47,6 @@ public class AdminController {
     // 새 문서 신청 요청 상세 조회
     @GetMapping("/admin/requests/new/{docs_request_id}")
     private Object getOneCreatedRequest(@PathVariable("docs_request_id") Long docsRequestId) {
-        // 권한 확인
-
-
-        // 요청 존재 확인
-
         NewReadResDTO modifiedRequest = docsRequestService.getOneCreatedRequest(docsRequestId);
         return ApiUtils.success(modifiedRequest);
     }
@@ -75,9 +55,6 @@ public class AdminController {
     // 새 문서 생성 요청 승락
     @PostMapping("/admin/approve/new/{docs_request_id}")
     private ResponseEntity<?> approveCreateRequest(@PathVariable("docs_request_id") Long docsRequestId) {
-
-        log.info("컨트롤러 접근완료");
-
         return ResponseEntity.ok(ApiUtils.success(adminService.approveNewDocs(docsRequestId)));
 
     }
@@ -85,12 +62,6 @@ public class AdminController {
     // 문서 수정 요청 승락
     @PostMapping("/admin/approve/update/{docs_request_id}")
     private ResponseEntity<?> approveModifiedRequest(@PathVariable("docs_request_id") Long docsRequestId) {
-        // 권한 확인
-
-
-        // 요청 존재 확인
-
-
         InfoEditResDTO updatedDocs = adminService.updateDocsFromRequest(docsRequestId);
         return ResponseEntity.ok().body(ApiUtils.success(updatedDocs));
     }
@@ -98,8 +69,7 @@ public class AdminController {
     // 문서 요청 반려
     @PostMapping("/admin/reject/{docs_request_id}")
     private ResponseEntity<?> rejectRequest(@PathVariable("docs_request_id") Long docsRequestId) {
-
-        docsRequestService.rejectRequest(docsRequestId);
+        adminService.rejectRequest(docsRequestId);
         return ResponseEntity.ok(ApiUtils.success("요청이 반려되었습니다."));
     }
 }

--- a/src/main/java/com/timcooki/jnuwiki/domain/member/controller/AdminController.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/member/controller/AdminController.java
@@ -6,7 +6,7 @@ import com.timcooki.jnuwiki.domain.member.DTO.response.admin.NewReadResDTO;
 import com.timcooki.jnuwiki.domain.member.DTO.response.admin.EditListReadResDTO;
 import com.timcooki.jnuwiki.domain.member.DTO.response.admin.EditReadResDTO;
 import com.timcooki.jnuwiki.util.ApiUtils;
-import com.timcooki.jnuwiki.domain.docsRequest.service.DocsRequestService;
+import com.timcooki.jnuwiki.domain.docsRequest.service.DocsRequestReadService;
 import com.timcooki.jnuwiki.domain.member.service.AdminService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,34 +20,34 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 @RequiredArgsConstructor
 public class AdminController {
-    private final DocsRequestService docsRequestService;
+    private final DocsRequestReadService docsRequestReadService;
     private final AdminService adminService;
 
     // 문서 기본정보 수정 요청 목록 조회
     @GetMapping("/admin/requests/update")
     private ResponseEntity<?> getModifiedRequests(@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        EditListReadResDTO modifiedRequests = docsRequestService.getModifiedRequestList(pageable);
+        EditListReadResDTO modifiedRequests = docsRequestReadService.getModifiedRequestList(pageable);
         return ResponseEntity.ok().body(ApiUtils.success(modifiedRequests));
     }
 
     // 새 문서 생성 요청 목록 조회
     @GetMapping("/admin/requests/new")
     private Object getCreatedRequests(@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        NewListReadResDTO createRequests = docsRequestService.getCreatedRequestList(pageable);
+        NewListReadResDTO createRequests = docsRequestReadService.getCreatedRequestList(pageable);
         return ApiUtils.success(createRequests);
     }
 
     // 문서 기본 정보 수정 요청 상세 조회
     @GetMapping("/admin/requests/update/{docs_request_id}")
     private Object getOneModifiedRequest(@PathVariable("docs_request_id") Long docsRequestId) {
-        EditReadResDTO modifiedRequest = docsRequestService.getOneModifiedRequest(docsRequestId);
+        EditReadResDTO modifiedRequest = docsRequestReadService.getOneModifiedRequest(docsRequestId);
         return ApiUtils.success(modifiedRequest);
     }
 
     // 새 문서 신청 요청 상세 조회
     @GetMapping("/admin/requests/new/{docs_request_id}")
     private Object getOneCreatedRequest(@PathVariable("docs_request_id") Long docsRequestId) {
-        NewReadResDTO modifiedRequest = docsRequestService.getOneCreatedRequest(docsRequestId);
+        NewReadResDTO modifiedRequest = docsRequestReadService.getOneCreatedRequest(docsRequestId);
         return ApiUtils.success(modifiedRequest);
     }
 

--- a/src/main/java/com/timcooki/jnuwiki/domain/member/controller/MemberController.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/member/controller/MemberController.java
@@ -17,14 +17,15 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
-@RestController
 @Slf4j
 @RequiredArgsConstructor
+@RestController
+@RequestMapping("/members")
 public class MemberController {
     private final MemberService memberService;
     private final RefreshTokenService refreshTokenService;
 
-    @PostMapping("/members/login")
+    @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody LoginReqDTO loginReqDTO){
 
         return memberService.login(loginReqDTO);
@@ -32,7 +33,7 @@ public class MemberController {
     }
 
     // refresh token 재발급
-    @PostMapping("/members/refresh-token")
+    @PostMapping("/refresh-token")
     public ResponseEntity<?> refreshToken(@RequestHeader(value = "set-cookie") String refreshToken){
 
         try{
@@ -44,13 +45,13 @@ public class MemberController {
 
     }
 
-    @PostMapping("/members/join")
+    @PostMapping("/join")
     public ResponseEntity<?> join(@RequestBody JoinReqDTO joinReqDTO){
 
         return memberService.join(joinReqDTO);
     }
 
-    @GetMapping("/members/info")
+    @GetMapping("/info")
     public ResponseEntity<?> info(@AuthenticationPrincipal UserDetails userDetails){
         ReadResDTO member = memberService.getInfo(userDetails);
 
@@ -58,7 +59,7 @@ public class MemberController {
     }
 
     // TODO AuthenticationPrincipal - SecurityContextHolder/Authentication도 고려
-    @PostMapping("/members/modify/change")
+    @PostMapping("/modify/change")
     public ResponseEntity<?> modifyInfo(@AuthenticationPrincipal UserDetails userDetails,
                                         @RequestBody EditReqDTO editReqDTO){
 
@@ -66,7 +67,7 @@ public class MemberController {
         return ResponseEntity.ok().body(ApiUtils.success(null));
     }
 
-    @GetMapping("/members/scrap")
+    @GetMapping("/scrap")
     public ResponseEntity<?> getScrappedDocsList(@AuthenticationPrincipal UserDetails userDetails, @PageableDefault(size = 20) Pageable pageable) {
         return ResponseEntity.ok(ApiUtils.success(memberService.getScrappedDocs(userDetails, pageable)));
     }

--- a/src/main/java/com/timcooki/jnuwiki/domain/member/service/AdminService.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/member/service/AdminService.java
@@ -28,7 +28,7 @@ public class AdminService {
     // TODO - 예외처리 수정
     // 새 문서 요청 승락
     @Transactional
-    public NewApproveResDTO approveNewDocs(Long docsRequestId){
+    public NewApproveResDTO approveNewDocs(Long docsRequestId) {
         DocsRequest docsRequest = docsRequestRepository.findById(docsRequestId).orElseThrow(
                 () -> new Exception404("존재하지 않는 요청입니다.")
         );
@@ -86,13 +86,10 @@ public class AdminService {
                 .build();
     }
 
+    public void rejectRequest(Long docsRequestId) {
+        // 요청 존재 확인
+        DocsRequest docsRequest = docsRequestRepository.findById(docsRequestId).orElseThrow(() -> new Exception404("존재하지 않는 요청입니다."));
 
-    public boolean findByEmail(String email){
-
-        if(memberRepository.findByEmail(email).isPresent()){
-            return true;
-        }else {
-            return false;
-        }
+        docsRequestRepository.delete(docsRequest);
     }
 }

--- a/src/main/java/com/timcooki/jnuwiki/domain/security/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/security/repository/RefreshTokenRepository.java
@@ -1,13 +1,15 @@
 package com.timcooki.jnuwiki.domain.security.repository;
 
+import com.timcooki.jnuwiki.domain.member.entity.Member;
 import com.timcooki.jnuwiki.domain.security.entity.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.Instant;
 import java.util.Optional;
 
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
     Optional<RefreshToken> findByToken(String token);
-
+    Optional<RefreshToken> findByMemberAndExpiredDateIsAfter(Member member, Instant expiredDate);
 }

--- a/src/main/java/com/timcooki/jnuwiki/domain/security/service/RefreshTokenService.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/security/service/RefreshTokenService.java
@@ -44,13 +44,13 @@ public class RefreshTokenService {
 
     public RefreshToken createRefreshToken(String email, Optional<Member> member) {
         // 로그인을 이미 한 유저라면?
-        // if(refreshTokenRepository.findByMemberId)
-
-        RefreshToken refreshToken = RefreshToken.builder()
-                .member(member.get())
-                .token(UUID.randomUUID().toString())
-                .expiredDate(Instant.now().plusMillis(1000*60*60))//1시간
-                .build();
+        RefreshToken refreshToken = refreshTokenRepository.findByMemberAndExpiredDateIsAfter(member.get(), Instant.now()).orElse(
+                RefreshToken.builder()
+                        .member(member.get())
+                        .token(UUID.randomUUID().toString())
+                        .expiredDate(Instant.now().plusMillis(1000*60*60))//1시간
+                        .build()
+        );
         return refreshTokenRepository.save(refreshToken);
     }
 

--- a/src/main/java/com/timcooki/jnuwiki/domain/security/service/RefreshTokenService.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/security/service/RefreshTokenService.java
@@ -51,7 +51,7 @@ public class RefreshTokenService {
                         .expiredDate(Instant.now().plusMillis(1000*60*60))//1시간
                         .build()
         );
-        return refreshTokenRepository.save(refreshToken);
+        return refreshToken;
     }
 
 

--- a/src/test/java/com/timcooki/jnuwiki/docs/DocsControllerTest.java
+++ b/src/test/java/com/timcooki/jnuwiki/docs/DocsControllerTest.java
@@ -37,6 +37,7 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
 @Import({
         AuthenticationConfig.class,
@@ -89,11 +90,8 @@ public class DocsControllerTest {
     @WithMockUser(username = "mminl@naver.cm", roles = "USER")
     public void findAll_test() throws Exception {
         // given
-        int page = 1;
-        int size = 10;
-
         Member member = Member.builder()
-                .email("momo@naver.com")
+                .email("mminl@naver.cm")
                 .nickName("mmmm")
                 .password("1235!dasd")
                 .role(MemberRole.USER)
@@ -146,8 +144,7 @@ public class DocsControllerTest {
         ResultActions result = mockMvc.perform(
                 MockMvcRequestBuilders
                         .get("/docs/1", docsId)
-                        .contentType(MediaType.APPLICATION_JSON)
-        );
+                        .contentType(MediaType.APPLICATION_JSON));
 
         String responseBody = result.andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
         System.out.println("테스트 : " + responseBody);

--- a/src/test/java/com/timcooki/jnuwiki/docs/DocsRepositoryTest.java
+++ b/src/test/java/com/timcooki/jnuwiki/docs/DocsRepositoryTest.java
@@ -11,7 +11,6 @@ import com.timcooki.jnuwiki.domain.member.entity.MemberRole;
 import com.timcooki.jnuwiki.domain.member.repository.MemberRepository;
 import com.timcooki.jnuwiki.domain.scrap.entity.Scrap;
 import com.timcooki.jnuwiki.domain.scrap.repository.ScrapRepository;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,8 +22,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
 import javax.persistence.EntityManager;
-import java.util.ArrayList;
-import java.util.List;
 
 @Import(ObjectMapper.class)
 @DataJpaTest

--- a/src/test/java/com/timcooki/jnuwiki/docs/DocsRepositoryTest.java
+++ b/src/test/java/com/timcooki/jnuwiki/docs/DocsRepositoryTest.java
@@ -9,6 +9,8 @@ import com.timcooki.jnuwiki.domain.docsRequest.entity.DocsCategory;
 import com.timcooki.jnuwiki.domain.member.entity.Member;
 import com.timcooki.jnuwiki.domain.member.entity.MemberRole;
 import com.timcooki.jnuwiki.domain.member.repository.MemberRepository;
+import com.timcooki.jnuwiki.domain.scrap.entity.Scrap;
+import com.timcooki.jnuwiki.domain.scrap.repository.ScrapRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -33,6 +35,9 @@ public class DocsRepositoryTest {
 
     @Autowired
     private MemberRepository memberRepository;
+
+    @Autowired
+    private ScrapRepository scrapRepository;
 
     @Autowired
     private EntityManager em;
@@ -100,6 +105,18 @@ public class DocsRepositoryTest {
                         .build()
         );
 
+        Scrap scrap1 = Scrap.builder()
+                .memberId(1L)
+                .docsId(1L)
+                .build();
+
+        Scrap scrap2 = Scrap.builder()
+                .memberId(1L)
+                .docsId(3L)
+                .build();
+
+        scrapRepository.save(scrap1);
+        scrapRepository.save(scrap2);
         docsRepository.findAll().forEach(System.out::println);
         docs.updateContent("테스트내용");
         em.flush();
@@ -137,7 +154,7 @@ public class DocsRepositoryTest {
     }
 
     @Test
-    //@DisplayName("최신 수정 시간순 정렬이 적용되어 있는가")
+    @DisplayName("최신 수정 시간순 정렬이 적용되어 있는가")
     public void docs_findAllByTime_test() throws JsonProcessingException {
         // given
         int page = 0;
@@ -166,6 +183,23 @@ public class DocsRepositoryTest {
         PageRequest pageRequest = PageRequest.of(page, size, sort);
         Page<Docs> docs = docsRepository.findAll(pageRequest);
         docs.forEach(d -> System.out.println(d.getDocsName() + " " + d.getModifiedAt()));
+
+        // then
+
+    }
+
+    @Test
+    @DisplayName("유저가 스크랩한 글만 조회가 되는가")
+    public void docs_scrap_test() throws JsonProcessingException {
+        // given
+        int page = 0;
+        int size = 6;
+        Sort sort = Sort.by(Sort.Direction.DESC, "createdAt");
+
+        // when
+        PageRequest pageRequest = PageRequest.of(page, size, sort);
+        Page<Docs> docs = docsRepository.mFindScrappedDocsByMemberId(1L, pageRequest);
+        docs.forEach(d -> System.out.println("조회된 문서의 Id" + d.getDocsId() + " 조회된 문서의 스크랩 시간 " + d.getCreatedAt()));
 
         // then
 

--- a/src/test/java/com/timcooki/jnuwiki/domain/docsRequest/DocsRequestControllerTest.java
+++ b/src/test/java/com/timcooki/jnuwiki/domain/docsRequest/DocsRequestControllerTest.java
@@ -1,26 +1,22 @@
 package com.timcooki.jnuwiki.domain.docsRequest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.timcooki.jnuwiki.domain.docs.controller.DocsController;
 import com.timcooki.jnuwiki.domain.docs.entity.DocsLocation;
 import com.timcooki.jnuwiki.domain.docsRequest.controller.DocsRequestController;
 import com.timcooki.jnuwiki.domain.docsRequest.dto.request.EditWriteReqDTO;
 import com.timcooki.jnuwiki.domain.docsRequest.dto.request.NewWriteReqDTO;
-import com.timcooki.jnuwiki.domain.docsRequest.dto.response.NewWriteResDTO;
 import com.timcooki.jnuwiki.domain.docsRequest.entity.DocsCategory;
 import com.timcooki.jnuwiki.domain.docsRequest.entity.DocsRequestType;
-import com.timcooki.jnuwiki.domain.docsRequest.service.DocsRequestService;
+import com.timcooki.jnuwiki.domain.docsRequest.service.DocsRequestWriteService;
 import com.timcooki.jnuwiki.domain.member.entity.Member;
 import com.timcooki.jnuwiki.domain.member.entity.MemberRole;
 import com.timcooki.jnuwiki.domain.member.service.MemberService;
 import com.timcooki.jnuwiki.domain.security.config.AuthenticationConfig;
 import com.timcooki.jnuwiki.domain.security.config.JwtFilter;
-import com.timcooki.jnuwiki.domain.security.config.MemberDetails;
 import com.timcooki.jnuwiki.domain.security.service.MemberSecurityService;
 import com.timcooki.jnuwiki.util.errors.GlobalExceptionHandler;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -28,7 +24,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -47,7 +42,7 @@ import java.nio.charset.StandardCharsets;
 public class DocsRequestControllerTest {
 
     @MockBean
-    private DocsRequestService docsRequestService;
+    private DocsRequestWriteService writeService;
 
     @MockBean
     private MemberService memberService;
@@ -82,7 +77,7 @@ public class DocsRequestControllerTest {
                 .build();
 
         String requestBody = om.writeValueAsString(editWriteReqDTO);
-        System.out.println("테스트 : " + requestBody);
+        System.out.println("요청전 : " + requestBody);
 
         // when
         ResultActions result = mvc.perform(
@@ -93,7 +88,7 @@ public class DocsRequestControllerTest {
         );
 
         String responseBody = result.andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
-        System.out.println("테스트 : " + responseBody);
+        System.out.println("요청후 : " + responseBody);
 
         // then
         result.andExpect(MockMvcResultMatchers.jsonPath("$.success").value("true"));
@@ -104,7 +99,7 @@ public class DocsRequestControllerTest {
     public void add_create_request() throws Exception {
         // given
         NewWriteReqDTO newWriteReqDTO = NewWriteReqDTO.builder()
-                .docsRequestType(DocsRequestType.MODIFIED)
+                .docsRequestType(DocsRequestType.CREATED)
                 .docsRequestName("ds")
                 .docsRequestLocation(new DocsLocation(12.0, 321.3))
                 .docsRequestCategory(DocsCategory.CAFE.getCategory())

--- a/src/test/java/com/timcooki/jnuwiki/domain/docsRequest/DocsRequestReadServiceTest.java
+++ b/src/test/java/com/timcooki/jnuwiki/domain/docsRequest/DocsRequestReadServiceTest.java
@@ -1,6 +1,6 @@
 package com.timcooki.jnuwiki.domain.docsRequest;
 
-import com.timcooki.jnuwiki.domain.docsRequest.service.DocsRequestService;
+import com.timcooki.jnuwiki.domain.docsRequest.service.DocsRequestReadService;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,10 +10,10 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 
 @SpringBootTest
-public class DocsRequestServiceTest {
+public class DocsRequestReadServiceTest {
 
     @Autowired
-    private DocsRequestService docsRequestService;
+    private DocsRequestReadService docsRequestReadService;
 
     @Test
     public void fifteen_check(){

--- a/src/test/java/com/timcooki/jnuwiki/domain/member/MemberControllerTest.java
+++ b/src/test/java/com/timcooki/jnuwiki/domain/member/MemberControllerTest.java
@@ -1,0 +1,109 @@
+package com.timcooki.jnuwiki.domain.member;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.timcooki.jnuwiki.domain.docsRequest.entity.DocsCategory;
+import com.timcooki.jnuwiki.domain.member.DTO.request.JoinReqDTO;
+import com.timcooki.jnuwiki.domain.member.DTO.response.ScrapResDTO;
+import com.timcooki.jnuwiki.domain.member.controller.MemberController;
+import com.timcooki.jnuwiki.domain.member.entity.Member;
+import com.timcooki.jnuwiki.domain.member.entity.MemberRole;
+import com.timcooki.jnuwiki.domain.member.repository.MemberRepository;
+import com.timcooki.jnuwiki.domain.member.service.MemberService;
+import com.timcooki.jnuwiki.domain.security.config.AuthenticationConfig;
+import com.timcooki.jnuwiki.domain.security.config.JwtFilter;
+import com.timcooki.jnuwiki.domain.security.repository.RefreshTokenRepository;
+import com.timcooki.jnuwiki.domain.security.service.MemberSecurityService;
+import com.timcooki.jnuwiki.domain.security.service.RefreshTokenService;
+import com.timcooki.jnuwiki.util.errors.GlobalExceptionHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MockMvcBuilder;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+@Import({
+        AuthenticationConfig.class,
+        JwtFilter.class,
+        GlobalExceptionHandler.class,
+        RefreshTokenService.class
+})
+@WebMvcTest(controllers = MemberController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+public class MemberControllerTest {
+
+    @MockBean
+    private MemberService memberService;
+    @MockBean
+    private MemberSecurityService memberSecurityService;
+    @MockBean
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired private MockMvc mvc;
+    @Autowired private ObjectMapper om;
+
+    @BeforeEach
+    void setUp() {
+        UserDetails userDetails = memberSecurityService.loadUserByUsername("test@test.com");
+//        this.mvc = MockMvcBuilders.standaloneSetup(new MemberController).build();
+    }
+
+    @Test
+    @DisplayName("마이페이지 내가 스크랩한 글 조회")
+    @WithMockUser(username = "test@test.com", roles = "USER")
+    public void get_scrapped_docsList_test() throws Exception {
+        // given
+        Member member = Member.builder()
+                .email("test@test.com")
+                .nickName("hihi")
+                .role(MemberRole.USER)
+                .password("1234!asdf")
+                .build();
+
+        UserDetails userDetails = memberSecurityService.loadUserByUsername("test@test.com");
+
+        List<ScrapResDTO> list = new ArrayList<>();
+        list.add(new ScrapResDTO(1L, "내용1", DocsCategory.CONV.getCategory()));
+        list.add(new ScrapResDTO(2L, "내용2", DocsCategory.CAFE.getCategory()));
+        list.add(new ScrapResDTO(3L, "내용3", DocsCategory.SCHOOL.getCategory()));
+
+        // stub
+        Mockito.when(memberService.getScrappedDocs(any(), any())).thenReturn(list);
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                MockMvcRequestBuilders
+                        .get("/members/scrap")
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 : " + responseBody);
+
+        // then
+        resultActions.andExpect(MockMvcResultMatchers.jsonPath("$.success").value("true"));
+    }
+}

--- a/src/test/java/com/timcooki/jnuwiki/domain/security/RefreshTokenRepositoryTest.java
+++ b/src/test/java/com/timcooki/jnuwiki/domain/security/RefreshTokenRepositoryTest.java
@@ -1,0 +1,102 @@
+package com.timcooki.jnuwiki.domain.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.timcooki.jnuwiki.domain.member.entity.Member;
+import com.timcooki.jnuwiki.domain.member.entity.MemberRole;
+import com.timcooki.jnuwiki.domain.member.repository.MemberRepository;
+import com.timcooki.jnuwiki.domain.security.entity.RefreshToken;
+import com.timcooki.jnuwiki.domain.security.repository.RefreshTokenRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import javax.persistence.EntityManager;
+import java.time.Instant;
+
+@Import(ObjectMapper.class)
+@DataJpaTest
+public class RefreshTokenRepositoryTest {
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private ObjectMapper om;
+
+    @BeforeEach
+    public void setUp() {
+        Member member1 = Member.builder()
+                .email("minl741@naver.com")
+                .nickName("momo")
+                .password("asbc1234!")
+                .role(MemberRole.USER)
+                .build();
+
+        Member member2 = Member.builder()
+                .email("213d@mmm.com")
+                .nickName("uu")
+                .password("asbc1234!")
+                .role(MemberRole.USER)
+                .build();
+        memberRepository.save(member1);
+        memberRepository.save(member2);
+
+        RefreshToken refreshToken1 = refreshTokenRepository.save(
+                RefreshToken.builder()
+                        .token("member 1의 만료된 토큰")
+                        .expiredDate(Instant.EPOCH)
+                        .member(member1)
+                        .build()
+        );
+
+        RefreshToken refreshToken2 = refreshTokenRepository.save(
+                RefreshToken.builder()
+                        .token("member 2의 만료된 토큰")
+                        .expiredDate(Instant.EPOCH)
+                        .member(member2)
+                        .build()
+        );
+
+        RefreshToken refreshToken3 = refreshTokenRepository.save(
+                RefreshToken.builder()
+                        .token("member 1의 만료되지 않은 토큰")
+                        .expiredDate(Instant.ofEpochSecond(2_000_000_000))
+                        .member(member1)
+                        .build()
+        );
+
+        RefreshToken refreshToken5 = refreshTokenRepository.save(
+                RefreshToken.builder()
+                        .token("member 2의 만료되지 않은 토큰")
+                        .expiredDate(Instant.ofEpochSecond(2_000_000_000))
+                        .member(member2)
+                        .build()
+        );
+
+        refreshTokenRepository.save(refreshToken1);
+        refreshTokenRepository.save(refreshToken2);
+        refreshTokenRepository.save(refreshToken3);
+        refreshTokenRepository.save(refreshToken3);
+        refreshTokenRepository.save(refreshToken5);
+        em.flush();
+        em.clear();
+    }
+
+    @Test
+    @DisplayName("특정 유저의 만료 시간 전의 리프레시 토큰만 조회되는가")
+    public void findBy_Member_And_ExpiredDate_IsAfter_test() {
+        // given
+        Member member = memberRepository.findByEmail("minl741@naver.com").get();
+        // when
+        RefreshToken token = refreshTokenRepository.findByMemberAndExpiredDateIsAfter(member, Instant.now()).get();
+        System.out.println(token.getExpiredDate() + " 시간이랑 멤버 " + token.getMember());
+
+        // then
+    }
+}

--- a/src/test/java/com/timcooki/jnuwiki/domain/security/RefreshTokenServiceTest.java
+++ b/src/test/java/com/timcooki/jnuwiki/domain/security/RefreshTokenServiceTest.java
@@ -1,0 +1,71 @@
+package com.timcooki.jnuwiki.domain.security;
+
+import com.timcooki.jnuwiki.domain.member.entity.Member;
+import com.timcooki.jnuwiki.domain.member.entity.MemberRole;
+import com.timcooki.jnuwiki.domain.member.repository.MemberRepository;
+import com.timcooki.jnuwiki.domain.security.entity.RefreshToken;
+import com.timcooki.jnuwiki.domain.security.repository.RefreshTokenRepository;
+import com.timcooki.jnuwiki.domain.security.service.RefreshTokenService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+
+@ExtendWith(MockitoExtension.class)
+public class RefreshTokenServiceTest {
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private RefreshTokenService refreshTokenService;
+
+    @BeforeEach
+    public void setUp() {
+        // Mock 객체를 초기화합니다.
+        MockitoAnnotations.initMocks(this);
+    }
+
+    // TODO: 테스트 stub이 실행될 때의 now와 서비스단 메서드가 실행될 때의 now가 달라서 에러 발생
+    @Test
+    @DisplayName("리프레시 토큰이 만료되지 않았을 경우 기존의 토큰이 리턴되는가?")
+    public void create_Refresh_Token_exist_test () {
+        // given
+        Member member = Member.builder()
+                .email("minl741@naver.com")
+                .nickName("momo")
+                .password("asbc1234!")
+                .role(MemberRole.USER)
+                .build();
+
+        RefreshToken expectedToken = RefreshToken.builder()
+                .token("member 1의 만료되지 않은 토큰")
+                .expiredDate(Instant.ofEpochSecond(2_000_000_000))
+                .member(member)
+                .build();
+
+        // stub
+        Mockito.when(refreshTokenRepository.findByMemberAndExpiredDateIsAfter(member, Instant.now())).thenReturn(Optional.of(expectedToken));
+        Mockito.when(refreshTokenRepository.save(expectedToken)).thenReturn(expectedToken);
+
+        // when
+        RefreshToken actualToken = refreshTokenService.createRefreshToken(member.getEmail(), Optional.of(member));
+
+        // then
+        assertEquals(expectedToken, actualToken);
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [x] 리팩토링
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 사항

- 사용하지 않는 임포트문 제거
- 리프레시 토큰 재발급 오류 해결
- docsRequestService를 Write, ReadService로 분리
- 스크랩한 글 조회 컨트롤러 test 작성
- 멤버 컨트롤러 중복되는 API RequestMapping로 추출

### 관련 이슈

closes #53 #52 
