### PR TITLE
멤버에 대한 각종 리팩토링

### DIFF
--- a/src/main/java/com/timcooki/jnuwiki/domain/docs/controller/DocsController.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/docs/controller/DocsController.java
@@ -2,14 +2,11 @@ package com.timcooki.jnuwiki.domain.docs.controller;
 
 import com.timcooki.jnuwiki.domain.docs.DTO.request.ContentEditReqDTO;
 import com.timcooki.jnuwiki.domain.docs.DTO.request.FindAllReqDTO;
-import com.timcooki.jnuwiki.domain.docs.DTO.response.ContentEditResDTO;
-import com.timcooki.jnuwiki.domain.docs.DTO.response.ListReadResDTO;
-import com.timcooki.jnuwiki.domain.docs.DTO.response.ReadResDTO;
-import com.timcooki.jnuwiki.domain.docs.service.DocsService;
-import com.timcooki.jnuwiki.domain.member.entity.Member;
+import com.timcooki.jnuwiki.domain.docs.service.DocsReadService;
+import com.timcooki.jnuwiki.domain.docs.service.DocsWriteService;
 import com.timcooki.jnuwiki.util.ApiUtils;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -21,34 +18,36 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 public class DocsController {
-    private final DocsService docsService;
+    private final DocsReadService docsReadService;
+    private final DocsWriteService docsWriteService;
 
     // 모든 문서 조회 - 최근 수정된 순으로
     // 좌표 사이로
     @GetMapping("/docs")
-    public ResponseEntity<?> docsFindAll(@AuthenticationPrincipal UserDetails userDetails, @PageableDefault(size = 50, sort = "modifiedAt", direction = Sort.Direction.DESC) Pageable pageable,
-                                         @RequestBody FindAllReqDTO findAllReqDTO) {
-        return ResponseEntity.ok().body(ApiUtils.success(docsService.getDocsList(pageable, findAllReqDTO)));
+    public ResponseEntity<?> docsFindAll(@RequestBody FindAllReqDTO findAllReqDTO, @PageableDefault(size = 50, sort = "modifiedAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        log.info("테스트 : {}", findAllReqDTO.rightUp().getLat());
+        return ResponseEntity.ok().body(ApiUtils.success(docsReadService.getDocsList(pageable, findAllReqDTO)));
     }
 
     // 문서 수정
     @PutMapping("/docs/{docs_id}")
     public ResponseEntity<?> modifyDocs(@PathVariable Long docs_id, @RequestBody ContentEditReqDTO contentEditReqDTO) {
-        return ResponseEntity.ok().body(ApiUtils.success(docsService.updateDocs(docs_id, contentEditReqDTO)));
+        return ResponseEntity.ok().body(ApiUtils.success(docsWriteService.updateDocs(docs_id, contentEditReqDTO)));
     }
 
     @GetMapping("/docs/{docs_id}")
     public ResponseEntity<?> docsFindOne(@AuthenticationPrincipal UserDetails userDetails, @PathVariable Long docs_id) {
         if (userDetails != null) {
-            return ResponseEntity.ok().body(ApiUtils.success(docsService.getOneDocs(userDetails.getUsername(), docs_id)));
+            return ResponseEntity.ok().body(ApiUtils.success(docsReadService.getOneDocs(userDetails.getUsername(), docs_id)));
         }
-        return ResponseEntity.ok().body(ApiUtils.success(docsService.getOneDocs(null, docs_id)));
+        return ResponseEntity.ok().body(ApiUtils.success(docsReadService.getOneDocs(null, docs_id)));
     }
 
     @GetMapping("/docs/search")
     public ResponseEntity<?> docsSearch(@RequestParam(value = "search") String search) {
 
-        return ResponseEntity.ok(ApiUtils.success(docsService.searchLike(search)));
+        return ResponseEntity.ok(ApiUtils.success(docsReadService.searchLike(search)));
     }
 }

--- a/src/main/java/com/timcooki/jnuwiki/domain/docs/service/DocsReadService.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/docs/service/DocsReadService.java
@@ -1,11 +1,7 @@
 package com.timcooki.jnuwiki.domain.docs.service;
 
-import com.timcooki.jnuwiki.domain.docs.DTO.request.ContentEditReqDTO;
 import com.timcooki.jnuwiki.domain.docs.DTO.request.FindAllReqDTO;
-import com.timcooki.jnuwiki.domain.docs.DTO.response.ContentEditResDTO;
-import com.timcooki.jnuwiki.domain.docs.DTO.response.ListReadResDTO;
-import com.timcooki.jnuwiki.domain.docs.DTO.response.ReadResDTO;
-import com.timcooki.jnuwiki.domain.docs.DTO.response.SearchReadResDTO;
+import com.timcooki.jnuwiki.domain.docs.DTO.response.*;
 import com.timcooki.jnuwiki.domain.docs.entity.Docs;
 import com.timcooki.jnuwiki.domain.docs.mapper.DocsMapper;
 import com.timcooki.jnuwiki.domain.docs.repository.DocsRepository;
@@ -18,77 +14,61 @@ import com.timcooki.jnuwiki.util.errors.exception.Exception404;
 import lombok.RequiredArgsConstructor;
 import org.mapstruct.factory.Mappers;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-public class DocsService {
+public class DocsReadService {
     private final DocsRepository docsRepository;
     private final MemberRepository memberRepository;
     private final ScrapRepository scrapRepository;
 
     // SecurityContextHolder로 로그인한 유저의 정보를 가져온다.
     private String getEmail(){
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        if(principal.equals("anonymousUser")){
-            return null;
-        }
-        UserDetails userDetails = (UserDetails)principal;
-        return userDetails.getUsername()==null?null: userDetails.getUsername();
+        Authentication loggedInUser = SecurityContextHolder.getContext().getAuthentication();
+        String email = loggedInUser.getName();
+        return email;
     }
 
-    public List<ListReadResDTO> getDocsList(Pageable pageable, FindAllReqDTO findAllReqDTO) {
-        Page<Docs> docsList = docsRepository.mfindAll(findAllReqDTO.leftDown(), findAllReqDTO.rightUp(),pageable);
+    public ListReadResDTO getDocsList(Pageable pageable, FindAllReqDTO findAllReqDTO) {
+        Page<Docs> docsList = docsRepository.mfindAll(findAllReqDTO.rightUp(),findAllReqDTO.leftDown(), pageable);
+        Optional<Member> member = memberRepository.findByEmail(getEmail());
+        List<Scrap> scrapList = member.isPresent() ? scrapRepository.findAllByMemberId(member.get().getMemberId()) : new ArrayList<>();
 
-        List<ListReadResDTO> result = docsList.stream()
-                .map(docs -> createListReadResDTO(docs, getEmail()))
+        int totalPages = docsList.getTotalPages();
+
+
+        List<OneOfListReadResDTO> result = docsList.getContent().stream()
+                .map(d -> OneOfListReadResDTO.builder()
+                        .docsId(d.getDocsId())
+                                .docsName(d.getDocsName())
+                                .docsCategory(d.getDocsCategory().getCategory())
+                                .scrap(!scrapList.isEmpty() && scrapList.stream()
+                                        .anyMatch(s -> Objects.equals(s.getDocsId(), d.getDocsId()))
+                                )
+                                .build()
+                        )
                 .collect(Collectors.toList());
 
-        return result;
+
+
+        return ListReadResDTO.builder()
+                .docsList(result)
+                .totalPages(totalPages)
+                .build();
     }
 
-    private ListReadResDTO createListReadResDTO(Docs docs, String email) {
-        boolean isScrap = false;
-        if (email != null) {
-            Member member = memberRepository.findByEmail(email).get();
-            List<Scrap> scrapList = scrapRepository.findAllByMemberId(member.getMemberId());
-            isScrap = scrapList.stream()
-                    .anyMatch(scrapItem -> scrapItem.getDocsId().equals(docs.getDocsId()));
 
-        }
-        return new ListReadResDTO(
-                docs.getDocsId(),
-                docs.getDocsName(),
-                docs.getDocsCategory().getCategory(),
-                isScrap
-        );
-    }
-
-    @Transactional
-    public ContentEditResDTO updateDocs(Long docsId, ContentEditReqDTO contentEditReqDTO) {
-        Docs docs = docsRepository.findById(docsId).orElseThrow(
-                () -> new Exception404("존재하지 않는 문서입니다.")
-        );
-        // TODO - 가입일 15일 체크 추가
-
-        docs.updateContent(contentEditReqDTO.docsContent());
-
-        return new ContentEditResDTO(
-                docs.getDocsId(),
-                docs.getDocsContent(),
-                docs.getModifiedAt().format(DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss"))
-        );
-    }
 
     public ReadResDTO getOneDocs(String email, Long docsId) {
         boolean scrap = false;

--- a/src/main/java/com/timcooki/jnuwiki/domain/docs/service/DocsWriteService.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/docs/service/DocsWriteService.java
@@ -1,0 +1,52 @@
+package com.timcooki.jnuwiki.domain.docs.service;
+
+import com.timcooki.jnuwiki.domain.docs.DTO.request.ContentEditReqDTO;
+import com.timcooki.jnuwiki.domain.docs.DTO.request.FindAllReqDTO;
+import com.timcooki.jnuwiki.domain.docs.DTO.response.*;
+import com.timcooki.jnuwiki.domain.docs.entity.Docs;
+import com.timcooki.jnuwiki.domain.docs.mapper.DocsMapper;
+import com.timcooki.jnuwiki.domain.docs.repository.DocsRepository;
+import com.timcooki.jnuwiki.domain.member.entity.Member;
+import com.timcooki.jnuwiki.domain.member.repository.MemberRepository;
+import com.timcooki.jnuwiki.domain.scrap.entity.Scrap;
+import com.timcooki.jnuwiki.domain.scrap.entity.ScrapId;
+import com.timcooki.jnuwiki.domain.scrap.repository.ScrapRepository;
+import com.timcooki.jnuwiki.util.errors.exception.Exception404;
+import lombok.RequiredArgsConstructor;
+import org.mapstruct.factory.Mappers;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class DocsWriteService {
+    private final DocsRepository docsRepository;
+    @Transactional
+    public ContentEditResDTO updateDocs(Long docsId, ContentEditReqDTO contentEditReqDTO) {
+        Docs docs = docsRepository.findById(docsId).orElseThrow(
+                () -> new Exception404("존재하지 않는 문서입니다.")
+        );
+        // TODO - 가입일 15일 체크 추가
+
+        docs.updateContent(contentEditReqDTO.docsContent());
+
+        return new ContentEditResDTO(
+                docs.getDocsId(),
+                docs.getDocsContent(),
+                docs.getModifiedAt().format(DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss"))
+        );
+    }
+
+
+}

--- a/src/main/java/com/timcooki/jnuwiki/domain/member/controller/AdminController.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/member/controller/AdminController.java
@@ -28,7 +28,7 @@ public class AdminController {
     @GetMapping("/requests/update")
     private ResponseEntity<?> getModifiedRequests(@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         EditListReadResDTO modifiedRequests = docsRequestReadService.getModifiedRequestList(pageable);
-        return ResponseEntity.ok().body(ApiUtils.success(modifiedRequests));
+        return ResponseEntity.ok(ApiUtils.success(modifiedRequests));
     }
 
     // 새 문서 생성 요청 목록 조회
@@ -63,7 +63,7 @@ public class AdminController {
     @PostMapping("/approve/update/{docs_request_id}")
     private ResponseEntity<?> approveModifiedRequest(@PathVariable("docs_request_id") Long docsRequestId) {
         InfoEditResDTO updatedDocs = adminWriteService.updateDocsFromRequest(docsRequestId);
-        return ResponseEntity.ok().body(ApiUtils.success(updatedDocs));
+        return ResponseEntity.ok(ApiUtils.success(updatedDocs));
     }
 
     // 문서 요청 반려

--- a/src/main/java/com/timcooki/jnuwiki/domain/member/controller/MemberController.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/member/controller/MemberController.java
@@ -29,44 +29,34 @@ public class MemberController {
 
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody LoginReqDTO loginReqDTO){
-
-        return memberWriteService.login(loginReqDTO);
-
+        return ResponseEntity.ok(memberWriteService.login(loginReqDTO));
     }
 
     // refresh token 재발급
     @PostMapping("/refresh-token")
     public ResponseEntity<?> refreshToken(@RequestHeader(value = "set-cookie") String refreshToken){
-
         try{
-            return refreshTokenService.renewToken(refreshToken);
+            return ResponseEntity.ok(refreshTokenService.renewToken(refreshToken));
         }catch (Exception e){
             return ResponseEntity.status(401).body(ApiUtils.error(e.getMessage(), HttpStatus.UNAUTHORIZED));
         }
-
-
     }
 
     @PostMapping("/join")
     public ResponseEntity<?> join(@RequestBody JoinReqDTO joinReqDTO){
-
-        return memberWriteService.join(joinReqDTO);
+        return ResponseEntity.ok(memberWriteService.join(joinReqDTO));
     }
 
     @GetMapping("/info")
     public ResponseEntity<?> info(@AuthenticationPrincipal UserDetails userDetails){
         ReadResDTO member = memberReadService.getInfo(userDetails);
-
-        return ResponseEntity.ok().body(ApiUtils.success(member));
+        return ResponseEntity.ok(ApiUtils.success(member));
     }
 
-    // TODO AuthenticationPrincipal - SecurityContextHolder/Authentication도 고려
     @PostMapping("/modify/change")
-    public ResponseEntity<?> modifyInfo(@AuthenticationPrincipal UserDetails userDetails,
-                                        @RequestBody EditReqDTO editReqDTO){
-
-        memberWriteService.editInfo(userDetails, editReqDTO);
-        return ResponseEntity.ok().body(ApiUtils.success(null));
+    public ResponseEntity<?> modifyInfo(@RequestBody EditReqDTO editReqDTO){
+        memberWriteService.editInfo(editReqDTO);
+        return ResponseEntity.ok(ApiUtils.success(null));
     }
 
     @GetMapping("/scrap")

--- a/src/main/java/com/timcooki/jnuwiki/domain/member/controller/MemberController.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/member/controller/MemberController.java
@@ -12,11 +12,15 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
+
+import java.nio.charset.Charset;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -28,39 +32,45 @@ public class MemberController {
     private final RefreshTokenService refreshTokenService;
 
     @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody LoginReqDTO loginReqDTO){
+    public ResponseEntity<?> login(@RequestBody LoginReqDTO loginReqDTO) {
         return ResponseEntity.ok(memberWriteService.login(loginReqDTO));
     }
 
     // refresh token 재발급
     @PostMapping("/refresh-token")
-    public ResponseEntity<?> refreshToken(@RequestHeader(value = "set-cookie") String refreshToken){
-        try{
-            return ResponseEntity.ok(refreshTokenService.renewToken(refreshToken));
-        }catch (Exception e){
+    public ResponseEntity<?> refreshToken(@RequestHeader(value = "set-cookie") String refreshToken) {
+        try {
+            String accessToken = refreshTokenService.renewToken(refreshToken);
+            return ResponseEntity.ok()
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .body(ApiUtils.success("토큰 재발급 성공"));
+
+        } catch (Exception e) {
             return ResponseEntity.status(401).body(ApiUtils.error(e.getMessage(), HttpStatus.UNAUTHORIZED));
         }
     }
 
     @PostMapping("/join")
-    public ResponseEntity<?> join(@RequestBody JoinReqDTO joinReqDTO){
-        return ResponseEntity.ok(memberWriteService.join(joinReqDTO));
+    public ResponseEntity<?> join(@RequestBody JoinReqDTO joinReqDTO) {
+        memberWriteService.join(joinReqDTO);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiUtils.success(null));
     }
 
     @GetMapping("/info")
-    public ResponseEntity<?> info(@AuthenticationPrincipal UserDetails userDetails){
-        ReadResDTO member = memberReadService.getInfo(userDetails);
-        return ResponseEntity.ok(ApiUtils.success(member));
+    public ResponseEntity<?> info() {
+        ReadResDTO memberInfo = memberReadService.getInfo();
+        return ResponseEntity.ok(ApiUtils.success(memberInfo));
     }
 
     @PostMapping("/modify/change")
-    public ResponseEntity<?> modifyInfo(@RequestBody EditReqDTO editReqDTO){
+    public ResponseEntity<?> modifyInfo(@RequestBody EditReqDTO editReqDTO) {
         memberWriteService.editInfo(editReqDTO);
         return ResponseEntity.ok(ApiUtils.success(null));
     }
 
     @GetMapping("/scrap")
-    public ResponseEntity<?> getScrappedDocsList(@AuthenticationPrincipal UserDetails userDetails, @PageableDefault(size = 20) Pageable pageable) {
-        return ResponseEntity.ok(ApiUtils.success(memberReadService.getScrappedDocs(userDetails, pageable)));
+    public ResponseEntity<?> getScrappedDocsList(@PageableDefault(size = 20) Pageable pageable) {
+        return ResponseEntity.ok(ApiUtils.success(memberReadService.getScrappedDocs(pageable)));
     }
 }
+

--- a/src/main/java/com/timcooki/jnuwiki/domain/member/service/MemberReadService.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/member/service/MemberReadService.java
@@ -11,6 +11,7 @@ import com.timcooki.jnuwiki.util.errors.exception.Exception404;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
@@ -19,21 +20,26 @@ import org.springframework.stereotype.Service;
 public class MemberReadService {
     private final MemberRepository memberRepository;
     private final DocsRepository docsRepository;
-    public ReadResDTO getInfo(UserDetails userDetails) {
-        Member memberOptional = memberRepository.findByEmail(userDetails.getUsername()).orElseThrow(
+    public ReadResDTO getInfo() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        UserDetails memberDetails = (UserDetails) principal;
+
+        Member member = memberRepository.findByEmail(memberDetails.getUsername()).orElseThrow(
                 () -> new Exception404("존재하지 않는 회원입니다.")
         );
 
-        ReadResDTO resDTO = ReadResDTO.builder()
-                .id(memberOptional.getMemberId())
-                .nickName(memberOptional.getNickName())
-                .password(memberOptional.getPassword())
+        return ReadResDTO.builder()
+                .id(member.getMemberId())
+                .nickName(member.getNickName())
+                .password(member.getPassword())
                 .build();
-        return resDTO;
     }
 
-    public ScrapListResDTO getScrappedDocs(UserDetails userDetails, Pageable pageable) {
-        Member member = memberRepository.findByEmail(userDetails.getUsername()).orElseThrow(
+    public ScrapListResDTO getScrappedDocs(Pageable pageable) {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        UserDetails memberDetails = (UserDetails) principal;
+
+        Member member = memberRepository.findByEmail(memberDetails.getUsername()).orElseThrow(
                 () -> new Exception404("존재하지 않는 회원입니다.")
         );
 

--- a/src/main/java/com/timcooki/jnuwiki/domain/member/service/MemberReadService.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/member/service/MemberReadService.java
@@ -47,7 +47,13 @@ public class MemberReadService {
 
         ScrapListResDTO list = ScrapListResDTO.builder()
                 .scrapList(docsList.stream()
-                        .map(d -> new ScrapResDTO(d.getDocsId(), d.getDocsName(), d.getDocsName(), d.getDocsLocation(), member.getNickName()))
+                        .map(d -> ScrapResDTO.builder()
+                                .docsId(d.getDocsId())
+                                .docsName(d.getDocsName())
+                                .docsCategory(d.getDocsCategory().getCategory())
+                                .docsRequestLocation(d.getDocsLocation())
+                                .member(member.getNickName())
+                                .build())
                         .toList())
                 .totalPages(docsList.getTotalPages())
                 .build();

--- a/src/main/java/com/timcooki/jnuwiki/domain/member/service/MemberWriteService.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/member/service/MemberWriteService.java
@@ -128,22 +128,6 @@ public class MemberWriteService {
         return memberRepository.findByEmail(email).isPresent();
     }
 
-    private boolean validationMember(String email, String password) {
-        // id가 있는지 확인
-        if (memberRepository.findByEmail(email).isEmpty()) {
-            return false;
-        }
-        System.out.println("id 있음");
-
-        Member loginMember = memberRepository.findByEmail(email).orElseThrow(
-                () -> new Exception404("존재하지 않는 회원입니다.")
-        );
-        System.out.println("이메일 얻어옴");
-
-        // 아이디에 대응되는 비밀번호가 맞는지 확인
-        return loginMember.getPassword().equals(passwordEncoder.encode(password));
-    }
-
     public boolean isPresentNickName(CheckNicknameReqDTO checkNicknameReqDTO) {
 
         return memberRepository.findByNickName(checkNicknameReqDTO.nickname()).isPresent();

--- a/src/main/java/com/timcooki/jnuwiki/domain/member/service/MemberWriteService.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/member/service/MemberWriteService.java
@@ -59,7 +59,7 @@ public class MemberWriteService {
                     () -> new Exception404("존재하지 않는 회원입니다.")
             );
 
-            RefreshToken refreshToken = refreshTokenService.createRefreshToken(email, member);
+            RefreshToken refreshToken = refreshTokenService.createRefreshToken(member);
             Long memberId = member.getMemberId();
             String memberRole = member.getRole().toString();
 

--- a/src/main/java/com/timcooki/jnuwiki/domain/member/service/MemberWriteService.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/member/service/MemberWriteService.java
@@ -19,6 +19,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -86,11 +87,8 @@ public class MemberWriteService {
 
 
     public ResponseEntity<?> join(JoinReqDTO joinReqDTO) {
-
         validEmail(joinReqDTO.email());
-
         duplicateCheckEmail(joinReqDTO.email());
-
         validPassword(joinReqDTO.password());
 
         Member member = Member.builder()
@@ -158,7 +156,9 @@ public class MemberWriteService {
     }
 
     @Transactional
-    public void editInfo(UserDetails userDetails, EditReqDTO editReqDTO) {
+    public void editInfo(EditReqDTO editReqDTO) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        UserDetails userDetails = (UserDetails) authentication.getDetails();
 
         Member member = memberRepository.findByEmail(userDetails.getUsername()).orElseThrow(
                 () -> new Exception404("존재하지 않는 회원입니다.")

--- a/src/main/java/com/timcooki/jnuwiki/domain/member/service/MemberWriteService.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/member/service/MemberWriteService.java
@@ -43,22 +43,23 @@ public class MemberWriteService {
     public ResponseEntity<?> login(LoginReqDTO loginReqDTO) {
         String email = loginReqDTO.email();
         String password = loginReqDTO.password();
-        validEmail(loginReqDTO.email());
-        validPassword(loginReqDTO.password());
 
+        validEmail(email);
+        validPassword(password);
 
         // AuthenticationManger에게 인증 진행 위임
         Authentication authentication = authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(email, password));
 
-
         // 인증되었다면,
         if (authentication.isAuthenticated()) {
             // 리프레시 토큰 발급
-            RefreshToken refreshToken = refreshTokenService.createRefreshToken(email, memberRepository.findByEmail(email));
+
             Member member = memberRepository.findByEmail(email).orElseThrow(
                     () -> new Exception404("존재하지 않는 회원입니다.")
             );
+
+            RefreshToken refreshToken = refreshTokenService.createRefreshToken(email, member);
             Long memberId = member.getMemberId();
             String memberRole = member.getRole().toString();
 
@@ -86,7 +87,7 @@ public class MemberWriteService {
     }
 
 
-    public ResponseEntity<?> join(JoinReqDTO joinReqDTO) {
+    public void join(JoinReqDTO joinReqDTO) {
         validEmail(joinReqDTO.email());
         duplicateCheckEmail(joinReqDTO.email());
         validPassword(joinReqDTO.password());
@@ -99,8 +100,6 @@ public class MemberWriteService {
                 .build();
 
         memberRepository.save(member);
-
-        return ResponseEntity.ok().body(ApiUtils.success(null));
     }
 
     private void validPassword(String password) {

--- a/src/main/java/com/timcooki/jnuwiki/domain/security/service/RefreshTokenService.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/security/service/RefreshTokenService.java
@@ -24,29 +24,25 @@ public class RefreshTokenService {
 
     @Value("${jwt.secret}")
     private String secretKey;
-    // private final MemberRepository memberRepository;
 
     @Autowired
     public RefreshTokenService(RefreshTokenRepository refreshTokenRepository) {
         this.refreshTokenRepository = refreshTokenRepository;
     }
 
-    public ResponseEntity<?> renewToken(String refreshToken){
+    public String renewToken(String refreshToken){
         Member member = findByToken(refreshToken).map(this::verifyExpiration)
                 .map(RefreshToken::getMember)
                 .orElseThrow(() -> new Exception401("인증되지 않은 토큰입니다."));
 
-        String accessToken = JwtUtil.createJwt(member.getEmail(), member.getRole().toString(), secretKey);
-        return ResponseEntity.ok()
-                .header(HttpHeaders.AUTHORIZATION, accessToken)
-                .body(ApiUtils.success(null));
+        return JwtUtil.createJwt(member.getEmail(), member.getRole().toString(), secretKey);
     }
 
-    public RefreshToken createRefreshToken(String email, Optional<Member> member) {
+    public RefreshToken createRefreshToken(Member member) {
         // 로그인을 이미 한 유저라면?
-        RefreshToken refreshToken = refreshTokenRepository.findByMemberAndExpiredDateIsAfter(member.get(), Instant.now()).orElse(
+        RefreshToken refreshToken = refreshTokenRepository.findByMemberAndExpiredDateIsAfter(member, Instant.now()).orElse(
                 RefreshToken.builder()
-                        .member(member.get())
+                        .member(member)
                         .token(UUID.randomUUID().toString())
                         .expiredDate(Instant.now().plusMillis(1000*60*60))//1시간
                         .build()

--- a/src/test/java/com/timcooki/jnuwiki/domain/docs/DocsReadServiceTest.java
+++ b/src/test/java/com/timcooki/jnuwiki/domain/docs/DocsReadServiceTest.java
@@ -1,0 +1,64 @@
+package com.timcooki.jnuwiki.domain.docs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.timcooki.jnuwiki.domain.docs.DTO.request.FindAllReqDTO;
+import com.timcooki.jnuwiki.domain.docs.DTO.response.ListReadResDTO;
+import com.timcooki.jnuwiki.domain.docs.entity.DocsLocation;
+import com.timcooki.jnuwiki.domain.docs.repository.DocsRepository;
+import com.timcooki.jnuwiki.domain.docs.service.DocsReadService;
+import com.timcooki.jnuwiki.domain.member.repository.MemberRepository;
+import com.timcooki.jnuwiki.domain.scrap.repository.ScrapRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.*;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+
+import static org.mockito.ArgumentMatchers.any;
+
+@SpringBootTest
+@WithAnonymousUser
+public class DocsReadServiceTest {
+
+    @Autowired
+    private DocsReadService docsReadService;
+    @Autowired
+    private DocsRepository docsRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private ScrapRepository scrapRepository;
+    @Autowired
+    private ObjectMapper om;
+
+    // TODO - Repository Mock으로 대체 후 테스트 코드 작성
+    @DisplayName("문서 조회 테스트")
+    @Test
+    public void findAll_test() throws Exception{
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+        FindAllReqDTO dto = FindAllReqDTO.builder()
+                .rightUp(DocsLocation.builder()
+                        .lat(40.0)
+                        .lng(40.0)
+                        .build())
+                .leftDown(DocsLocation.builder()
+                        .lat(30.0)
+                        .lng(30.0)
+                        .build())
+                .build();
+
+
+        // when
+        ListReadResDTO response = docsReadService.getDocsList(pageable, dto);
+
+        // then
+        String result1 = om.writeValueAsString(response);
+        System.out.println("테스트 결과 :" + result1);
+        Assertions.assertEquals(1L, response.docsList().get(0).docsId());
+    }
+
+
+}

--- a/src/test/java/com/timcooki/jnuwiki/domain/member/MemberControllerTest.java
+++ b/src/test/java/com/timcooki/jnuwiki/domain/member/MemberControllerTest.java
@@ -67,7 +67,7 @@ public class MemberControllerTest {
         ScrapListResDTO listResDTO = new ScrapListResDTO(list, 3);
 
         // stub
-        Mockito.when(memberReadService.getScrappedDocs(any(), any())).thenReturn(listResDTO);
+        Mockito.when(memberReadService.getScrappedDocs(any())).thenReturn(listResDTO);
 
         // when
         ResultActions resultActions = mvc.perform(


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 사항

- 멤버, 어드민 컨트롤러 응답 시 body 값을 ResponseEntity.ok() 인자 전달로 통일
- UserDetails 서비스단에서 호출함에 따라 파라미터 제거
- 서비스단의 회원가입 메서드 반환 타입을 ResponseEntity 에서 void 로 변경
- 사용하지 않는 email 인자 및 메서드 제거
- 스크랩한 글 조회에서 문서 매핑 시 builder 활용으로 변경

### 관련 이슈

closes #66 
