### PR TITLE
엑세스 토큰 재발급 시 Bearer 제거된 쿠키를 서버단에서 붙이도록 수정

### DIFF
--- a/src/main/java/com/timcooki/jnuwiki/domain/security/config/JwtProvider.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/security/config/JwtProvider.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class JwtProvider {
     private static String secretKey;
-    private static final String PREFIX = "Bearer ";
+    public static final String PREFIX = "Bearer ";
     private static final Long SECOND = 1000L;
     private static final Long ACCESS_TOKEN_EXP_MS = SECOND * 60 * 5L; // 5분
     private static final Long REFRESH_TOKEN_EXP_MS = SECOND * 60 * 10L; // 10분

--- a/src/main/java/com/timcooki/jnuwiki/domain/security/service/RefreshTokenService.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/security/service/RefreshTokenService.java
@@ -6,18 +6,18 @@ import com.timcooki.jnuwiki.domain.security.repository.RefreshTokenRepository;
 import com.timcooki.jnuwiki.domain.security.config.JwtProvider;
 import com.timcooki.jnuwiki.util.errors.exception.Exception401;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
-
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RefreshTokenService {
     private final RefreshTokenRepository refreshTokenRepository;
 
-    // refreshToken이 만료되지 않았다면 accessToken을 재발급
     public String renewAccessToken(String refreshToken) {
-        RefreshToken existToken = refreshTokenRepository.findByToken(refreshToken)
+        RefreshToken existToken = refreshTokenRepository.findByToken(JwtProvider.PREFIX + refreshToken)
                 .orElseThrow(() -> new Exception401("인증되지 않은 토큰입니다."));
 
         verifyExpiration(existToken);


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 사항

- 엑세스 토큰 재발급 시 Bearer 제거된 쿠키를 서버단에서 붙이도록 수정

### 관련 이슈

closes #121
