### PR TITLE
시큐리티 /access-token로 바뀐 url에 permitAll, 로그인 시 리프레시 토큰 무조건 새로 발급

### DIFF
--- a/src/main/java/com/timcooki/jnuwiki/domain/member/service/MemberValidator.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/member/service/MemberValidator.java
@@ -11,7 +11,8 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class MemberValidator {
-    private MemberRepository memberRepository;
+    private final MemberRepository memberRepository;
+
     public void validateEmailDuplication(String email) {
         if (memberRepository.existsByEmail(email)) {
             throw new Exception400("존재하는 이메일 입니다.");

--- a/src/main/java/com/timcooki/jnuwiki/domain/security/config/AuthenticationConfig.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/security/config/AuthenticationConfig.java
@@ -1,9 +1,14 @@
 package com.timcooki.jnuwiki.domain.security.config;
 
 import com.timcooki.jnuwiki.domain.security.service.MemberSecurityService;
+import com.timcooki.jnuwiki.util.errors.exception.Exception401;
+import com.timcooki.jnuwiki.util.errors.exception.Exception403;
 import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
@@ -17,7 +22,9 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.servlet.HandlerExceptionResolver;
 
+@Slf4j
 @EnableWebSecurity
 @Configuration
 @RequiredArgsConstructor
@@ -34,7 +41,8 @@ public class AuthenticationConfig {
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity,
+                                                   @Autowired @Qualifier("handlerExceptionResolver") final HandlerExceptionResolver resolver) throws Exception {
         return httpSecurity
                 .httpBasic()
                 .disable()
@@ -49,10 +57,22 @@ public class AuthenticationConfig {
                 .apply(new CustomSecurityFilterManager())
 
                 .and()
+                .exceptionHandling().authenticationEntryPoint((request, response, authException) -> {
+                    log.info("{}, {}", request.getRemoteAddr(), authException.getMessage());
+                    resolver.resolveException(request, response, null, new Exception401("인증되지 않은 사용자입니다."));
+                })
+
+                .and()
+                .exceptionHandling().accessDeniedHandler((request, response, accessDeniedException) -> {
+                    log.info("{}, {}", request.getRemoteAddr(), accessDeniedException.getMessage());
+                    resolver.resolveException(request, response, null, new Exception403("접근 권한이 없습니다."));
+                })
+
+                .and()
                 .authorizeRequests()
                 .antMatchers(HttpMethod.GET, "/docs/**").permitAll()
 
-                .antMatchers("/members/join", "/members/login", "/members/refresh-token", "/members/check/**")
+                .antMatchers("/members/join", "/members/login", "/members/access-token", "/members/check/**")
                 .permitAll()
 
                 .antMatchers("/swagger-ui/**", "/v3/**")

--- a/src/main/java/com/timcooki/jnuwiki/domain/security/config/JwtFilter.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/security/config/JwtFilter.java
@@ -1,10 +1,9 @@
 package com.timcooki.jnuwiki.domain.security.config;
 
 
-import static com.timcooki.jnuwiki.domain.security.config.JwtProvider.cutTokenPrefix;
-
 import com.timcooki.jnuwiki.domain.member.entity.Member;
 import com.timcooki.jnuwiki.domain.member.entity.MemberRole;
+import com.timcooki.jnuwiki.util.TimeFormatter;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.MalformedJwtException;
@@ -42,9 +41,8 @@ public class JwtFilter extends BasicAuthenticationFilter {
         }
 
         try {
-            String token = cutTokenPrefix(bearerToken);
-            String email = (String) JwtProvider.getClaims(token).get("memberEmail");
-            MemberRole memberRole = MemberRole.valueOf((String) JwtProvider.getClaims(token).get("memberRole"));
+            String email = (String) JwtProvider.getClaims(bearerToken).get("memberEmail");
+            MemberRole memberRole = MemberRole.valueOf((String) JwtProvider.getClaims(bearerToken).get("memberRole"));
             log.info("email: {}, role: {}", email, memberRole);
 
             MemberDetails userDetails = new MemberDetails(

--- a/src/main/java/com/timcooki/jnuwiki/domain/security/config/JwtProvider.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/security/config/JwtProvider.java
@@ -54,12 +54,12 @@ public class JwtProvider {
     public static Claims getClaims(String token) {
         return Jwts.parser()
                 .setSigningKey(secretKey)
-                .parseClaimsJws(token)
+                .parseClaimsJws(cutTokenPrefix(token))
                 .getBody();
     }
 
     public static Instant getExpiration(String token) {
-        return getClaims(cutTokenPrefix(token))
+        return getClaims(token)
                 .getExpiration()
                 .toInstant();
     }

--- a/src/main/java/com/timcooki/jnuwiki/domain/security/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/security/repository/RefreshTokenRepository.java
@@ -13,5 +13,4 @@ import java.util.Optional;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
     Optional<RefreshToken> findByToken(String token);
     List<RefreshToken> findByMemberAndExpiredDateIsAfter(Member member, Instant expiredDate);
-    boolean existsByMemberAndExpiredDateIsAfter(Member member, Instant expiredDate);
 }

--- a/src/main/java/com/timcooki/jnuwiki/domain/security/service/RefreshTokenService.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/security/service/RefreshTokenService.java
@@ -10,7 +10,6 @@ import com.timcooki.jnuwiki.domain.security.repository.RefreshTokenRepository;
 import com.timcooki.jnuwiki.domain.security.config.JwtProvider;
 import com.timcooki.jnuwiki.util.TimeFormatter;
 import com.timcooki.jnuwiki.util.errors.exception.Exception401;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -42,11 +41,6 @@ public class RefreshTokenService {
 
 
     public RefreshToken createRefreshToken(Member member) {
-        if (refreshTokenRepository.existsByMemberAndExpiredDateIsAfter(member, Instant.now())) {
-            List<RefreshToken> refreshTokens = refreshTokenRepository.findByMemberAndExpiredDateIsAfter(member, Instant.now());
-            return refreshTokens.get(refreshTokens.size() - 1);
-        }
-
         String refreshToken = JwtProvider.createRefreshToken(member.getEmail(), member.getRole().toString());
         Instant expiration = JwtProvider.getExpiration(refreshToken);
 
@@ -60,7 +54,6 @@ public class RefreshTokenService {
 
     public void verifyExpiration(RefreshToken token) {
         if (token.getExpiredDate().isBefore(Instant.now())) {
-            refreshTokenRepository.delete(token);
             throw new Exception401("리프레시 토큰이 만료되었습니다. 재로그인을 해주세요.");
         }
     }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [x] 리팩토링
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 사항

- 리프레시 토큰 발급 시 무조건 새로 발급
  - 기존 레거시 로직: 로그인 시 해당 회원의 만료되지 않은 리프레시 토큰 발급 있다면 새로 생성하지 않고 기존 것 리턴
  - 변경한 로직: 로그인 시 리프레시 토큰 무조건 새로 발급 
- 시큐리티 /access-token로 바뀐 url에 permitAll 부여
  - 필터에서 발생한 에러를 따로 처리하지 않아 예외 처리 X -> exceptionHandling 로 추가
- MemberRepository 누락된 final 추가

### 관련 이슈

closes #124 
