### PR TITLE
엑세스 재발급 만료 시간 수정 및 토큰 만료 시간 연장

### DIFF
--- a/src/main/java/com/timcooki/jnuwiki/domain/security/config/JwtProvider.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/security/config/JwtProvider.java
@@ -13,9 +13,9 @@ import org.springframework.stereotype.Component;
 public class JwtProvider {
     private static String secretKey;
     public static final String PREFIX = "Bearer ";
-    private static final Long MINUTE = 1000L * 60;
-    private static final Long ACCESS_TOKEN_EXP_MS = 3 * MINUTE; // 3분
-    private static final Long REFRESH_TOKEN_EXP_MS = 60 * MINUTE * 24; // 1일 = 60분 * 24시간
+    private static final Long HOUR = 1000L * 60 * 60;
+    private static final Long ACCESS_TOKEN_EXP_MS = HOUR; // 1시간
+    private static final Long REFRESH_TOKEN_EXP_MS = 24 * HOUR * 14; // 2주
 
     @Value("${jwt.secret}")
     public void setSecretKey(String secretKey) {

--- a/src/main/java/com/timcooki/jnuwiki/domain/security/service/RefreshTokenService.java
+++ b/src/main/java/com/timcooki/jnuwiki/domain/security/service/RefreshTokenService.java
@@ -27,11 +27,12 @@ public class RefreshTokenService {
                 .orElseThrow(() -> new Exception401("인증되지 않은 토큰입니다."));
 
         verifyExpiration(existToken);
-        Instant expiration = JwtProvider.getExpiration(refreshToken);
-
         Member member = existToken.getMember();
+        String accessToken = JwtProvider.createAccessToken(member.getEmail(), member.getRole().toString());
+        Instant expiration = JwtProvider.getExpiration(accessToken);
+
         return WrapAccessTokenResDTO.builder()
-                .accessToken(JwtProvider.createAccessToken(member.getEmail(), member.getRole().toString()))
+                .accessToken(accessToken)
                 .accessTokenResDTO(AccessTokenResDTO.builder()
                         .accessTokenExpiration(expiration.toEpochMilli())
                         .accessTokenFormattedExpiration(TimeFormatter.format(expiration))


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 사항

- 엑세스 재발급 시 만료 시간 수정
-  엑세스 3분 -> 1시간, 리프레시 1일 -> 2주로 만료시간 연장

### 관련 이슈

closes #131 
